### PR TITLE
Add layer options tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         <button id="toggle_only_layer">Only</span>
       </div>
       <x-palette></x-palette>
+      <layer-options></layer-options>
     </side>
     <main name="viewport">
       <x-renderer></x-renderer>

--- a/layerOptions.js
+++ b/layerOptions.js
@@ -1,0 +1,60 @@
+import { Scenario } from "./scenario.js";
+
+export class LayerOptions extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback() {
+    this.render();
+    this.shadowRoot.addEventListener("click", this.onClick.bind(this));
+    window.addEventListener("update.ui", () => this.update());
+  }
+
+  onClick(event) {
+    const path = event.composedPath();
+    if (path.includes(this.shadowRoot.querySelector("#add_layer"))) {
+      Scenario.getInstance().addLayer();
+      this.update();
+    } else if (path.includes(this.shadowRoot.querySelector("#remove_layer"))) {
+      Scenario.getInstance().removeLayer();
+      this.update();
+    }
+  }
+
+  update() {
+    const countSpan = this.shadowRoot.querySelector("#layer_count");
+    if (countSpan) {
+      countSpan.textContent = Scenario.getInstance().layerCount;
+    }
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          border: 1px solid #333;
+          padding: 4px;
+          margin-top: 4px;
+        }
+        .row {
+          display: flex;
+          gap: 4px;
+        }
+      </style>
+      <details open>
+        <summary>Layer Options</summary>
+        <div class="row">
+          <button id="add_layer">Add</button>
+          <button id="remove_layer">Remove</button>
+        </div>
+        <div>Layer count: <span id="layer_count"></span></div>
+      </details>
+    `;
+    this.update();
+  }
+}
+
+customElements.define("layer-options", LayerOptions);

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ import './palette.js';
 import './tileElement.js';
 import { ScenarioOptionsModal } from "./scenarioOptionsModal.js";
 import { ContextWheel } from './contextWheel.js';
+import './layerOptions.js';
 
 /*
  * In this file all the different modules are imported, used and fused together

--- a/scenario.js
+++ b/scenario.js
@@ -137,6 +137,9 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
   incrementLayer() {
     let newLayer = this.currentLayer + 1;
 
+    if (newLayer > this.layerCount - 1)
+      newLayer = this.layerCount - 1;
+
     if (newLayer > Scenario.DEFAULT_UPPER_LAYER_LIMIT - 1)
       newLayer = Scenario.DEFAULT_UPPER_LAYER_LIMIT - 1;
 
@@ -150,6 +153,26 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
       newLayer = Scenario.DEFAULT_LOWER_LAYER_LIMIT;
 
     this.currentLayer = newLayer;
+  }
+
+  addLayer() {
+    if (this.layerCount >= Scenario.DEFAULT_UPPER_LAYER_LIMIT)
+      return;
+    this.layerCount += 1;
+    this.fireUpdate();
+  }
+
+  removeLayer() {
+    if (this.layerCount <= 1)
+      return;
+    this.layerCount -= 1;
+    this.mapCells.forEach(cell => {
+      delete cell.tiles[this.layerCount];
+    });
+    if (this.currentLayer >= this.layerCount) {
+      this.currentLayer = this.layerCount - 1;
+    }
+    this.fireUpdate();
   }
 
   setMapHeight(height) {


### PR DESCRIPTION
## Summary
- add new layer options sidebar tab to increase or decrease the scenario layers
- import the new module in `main.js`
- limit layer navigation to available layers and add add/remove logic in scenario class

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845f20f985c8322aaf96616ffb5896f