### PR TITLE
Move layer options UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       <button id="scenario_options">Options</button>
     </nav>
     <side>
+      <layer-options></layer-options>
       <button id="toggle_stats">Show details</button>
       <button id="toggle_details">Show cell details</button>
       <div class="side_row">
@@ -35,7 +36,6 @@
         <button id="toggle_only_layer">Only</span>
       </div>
       <x-palette></x-palette>
-      <layer-options></layer-options>
     </side>
     <main name="viewport">
       <x-renderer></x-renderer>

--- a/layerOptions.js
+++ b/layerOptions.js
@@ -44,7 +44,7 @@ export class LayerOptions extends HTMLElement {
           gap: 4px;
         }
       </style>
-      <details open>
+      <details>
         <summary>Layer Options</summary>
         <div class="row">
           <button id="add_layer">Add</button>


### PR DESCRIPTION
## Summary
- keep the layer options panel collapsed by default
- place layer options at the top of the sidebar

## Testing
- `node --check layerOptions.js`

------
https://chatgpt.com/codex/tasks/task_e_6845f4366cac832289da6a916fe85c09