### PR TITLE
Move current layer controls into layer options

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,12 +29,6 @@
       <div>Current tile: <span id="current_tile"></span></div>
       <span>Current brush:</span>
       <x-tile-element name="brush_preview"></x-tile-element >
-      <div class="side_row">
-        <button id="layer_down">-</button>
-        <span name="current_layer">Current layer</span>
-        <button id="layer_up">+</button>
-        <button id="toggle_only_layer">Only</span>
-      </div>
       <x-palette></x-palette>
     </side>
     <main name="viewport">

--- a/layerOptions.js
+++ b/layerOptions.js
@@ -24,9 +24,14 @@ export class LayerOptions extends HTMLElement {
   }
 
   update() {
+    const scenario = Scenario.getInstance();
     const countSpan = this.shadowRoot.querySelector("#layer_count");
     if (countSpan) {
-      countSpan.textContent = Scenario.getInstance().layerCount;
+      countSpan.textContent = scenario.layerCount;
+    }
+    const layerView = this.shadowRoot.querySelector('[name="current_layer"]');
+    if (layerView) {
+      layerView.textContent = `Current layer: ${scenario.currentLayer}`;
     }
   }
 
@@ -43,6 +48,10 @@ export class LayerOptions extends HTMLElement {
           display: flex;
           gap: 4px;
         }
+        .row > * {
+          flex: 1 1 1px;
+          text-wrap: nowrap;
+        }
       </style>
       <details>
         <summary>Layer Options</summary>
@@ -51,6 +60,12 @@ export class LayerOptions extends HTMLElement {
           <button id="remove_layer">Remove</button>
         </div>
         <div>Layer count: <span id="layer_count"></span></div>
+        <div class="row">
+          <button id="layer_down">-</button>
+          <span name="current_layer">Current layer</span>
+          <button id="layer_up">+</button>
+          <button id="toggle_only_layer">Only</button>
+        </div>
       </details>
     `;
     this.update();

--- a/main.js
+++ b/main.js
@@ -67,23 +67,28 @@ document.addEventListener("DOMContentLoaded", function () {
     fileInput.click();
   });
 
-  let layerUpButton = document.querySelector(`button#layer_up`);
-  let layerDownButton = document.querySelector(`button#layer_down`);
-  let layerView = document.querySelector(`span[name="current_layer"]`);
-  let layerOnlyButton = document.querySelector(`button#toggle_only_layer`);
-  layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
-  layerOnlyButton.addEventListener('click', function () {
+  const layerOptions = document.querySelector('layer-options');
+  const layerShadow = layerOptions?.shadowRoot;
+  let layerUpButton = layerShadow?.querySelector(`#layer_up`);
+  let layerDownButton = layerShadow?.querySelector(`#layer_down`);
+  let layerView = layerShadow?.querySelector('[name="current_layer"]');
+  let layerOnlyButton = layerShadow?.querySelector(`#toggle_only_layer`);
+  if (layerView)
+    layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
+  layerOnlyButton?.addEventListener('click', function () {
     renderer.toggleRenderOnlyCurrentLayer();
   });
-  layerUpButton.addEventListener('click', function () {
+  layerUpButton?.addEventListener('click', function () {
     Scenario.getInstance().incrementLayer();
-    layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
+    if (layerView)
+      layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
     renderer.lazyRender();
   });
 
-  layerDownButton.addEventListener('click', function () {
+  layerDownButton?.addEventListener('click', function () {
     Scenario.getInstance().decrementLayer();
-    layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
+    if (layerView)
+      layerView.innerHTML = `Current layer: ${Scenario.getInstance().currentLayer}`;
     renderer.lazyRender();
   });
 


### PR DESCRIPTION
## Summary
- include current layer controls in `<layer-options>` component
- remove old side panel current layer section
- update main.js to query layer controls from shadow DOM

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845f71374fc8322a17dc8d57ce62e3d