### PR TITLE
Add default palette generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <button id="load">Load Scenario</button>
       <button id="new_scenario">New Scenario</button>
       <button id="load_palette">Load Palette</button>
+      <button id="generate_palette">Generate Palette</button>
       <button id="scenario_options">Options</button>
     </nav>
     <side>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 import { Scenario } from "./scenario.js";
 import { Tools } from "./tools.js";
+import { defaultImage, defaultImageWidth, defaultImageHeight } from "./staticData.js";
 //import './renderer.js';
 import './canvasRenderer.js';
 import './palette.js';
@@ -185,6 +186,15 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     fileInput.click();
+  });
+
+  let generatePaletteButton = document.querySelector("button#generate_palette");
+  generatePaletteButton.addEventListener("click", function () {
+    const scenario = Scenario.getInstance();
+    if (scenario.getPalette().length > 0)
+      return;
+    scenario.pushImageIntoPalette(defaultImage, defaultImageWidth, defaultImageHeight);
+    renderer.lazyRender();
   });
 
   let newScenarioButton = document.querySelector("button#new_scenario");


### PR DESCRIPTION
## Summary
- add a UI button to create a default palette
- implement JS logic to generate a default tile when palette is empty

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff80cdf083228961712479fe2f3e