### PR TITLE
Improve layer options styling

### DIFF
--- a/layerOptions.js
+++ b/layerOptions.js
@@ -41,16 +41,19 @@ export class LayerOptions extends HTMLElement {
         :host {
           display: block;
           border: 1px solid #333;
+          border-radius: 4px;
           padding: 4px;
           margin-top: 4px;
+          background: #444;
         }
         .row {
           display: flex;
           gap: 4px;
+          margin-bottom: 4px;
         }
         .row > * {
           flex: 1 1 1px;
-          text-wrap: nowrap;
+          white-space: nowrap;
         }
       </style>
       <details>

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ nav label {
   color: #fff;
   padding: 0;
   border: 1px solid #999;
-  display:: block;
+  display: block;
 }
 
 label input {
@@ -140,5 +140,5 @@ x-renderer {
 
 .side_row > * {
   flex: 1 1 1px;
-  text-wrap: nowrap;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- fix `display::` typo
- use `white-space` instead of `text-wrap`
- style layer options container with border radius and background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ff9a2f7c832297cd7cfe2e6fd238