### PR TITLE
Fix layer options button styles

### DIFF
--- a/layerOptions.js
+++ b/layerOptions.js
@@ -55,6 +55,15 @@ export class LayerOptions extends HTMLElement {
           flex: 1 1 1px;
           white-space: nowrap;
         }
+        button {
+          background: #555;
+          color: #FFF;
+          cursor: pointer;
+          border: 2px solid #999;
+        }
+        button:hover {
+          background: #777;
+        }
       </style>
       <details>
         <summary>Layer Options</summary>


### PR DESCRIPTION
## Summary
- style buttons inside the `layer-options` component to match the rest of the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846015683b483229eed3739e7f86181