### PR TITLE
Add palette generator with 12 colored tiles

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,6 +9,18 @@ import { ScenarioOptionsModal } from "./scenarioOptionsModal.js";
 import { ContextWheel } from './contextWheel.js';
 import './layerOptions.js';
 
+function generateColorTile(color, width, height) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+  return new Promise(resolve => {
+    canvas.toBlob(blob => resolve(blob), 'image/png');
+  });
+}
+
 /*
  * In this file all the different modules are imported, used and fused together
  */
@@ -189,11 +201,20 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   let generatePaletteButton = document.querySelector("button#generate_palette");
-  generatePaletteButton.addEventListener("click", function () {
+  generatePaletteButton.addEventListener("click", async function () {
     const scenario = Scenario.getInstance();
     if (scenario.getPalette().length > 0)
       return;
-    scenario.pushImageIntoPalette(defaultImage, defaultImageWidth, defaultImageHeight);
+    const colors = [
+      '#ff0000', '#00ff00', '#0000ff', '#ffff00',
+      '#00ffff', '#ff00ff', '#ffffff', '#000000',
+      '#808080', '#ffa500', '#800080', '#a52a2a'
+    ];
+
+    for (const color of colors) {
+      const blob = await generateColorTile(color, defaultImageWidth, defaultImageHeight);
+      scenario.pushImageIntoPalette(blob, defaultImageWidth, defaultImageHeight, color);
+    }
     renderer.lazyRender();
   });
 

--- a/scenario.js
+++ b/scenario.js
@@ -98,8 +98,8 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     this.fireUpdate();
   }
 
-  pushImageIntoPalette(image, width, height) {
-    let tile = new Tile(this.palette.length, width, height, image);
+  pushImageIntoPalette(image, width, height, color = "#FF00FF") {
+    let tile = new Tile(this.palette.length, width, height, image, color);
     this.palette.push(tile);
     this.fireUpdate();
   }

--- a/tile.js
+++ b/tile.js
@@ -10,17 +10,25 @@ export class Tile {
   index= -1;
   width = 64;
   height = 64;
-  image = null;
+  image = null; // string URL for rendering
+  blob = null;
   color = "#FF00FF";
   properties = {
     layer: 0,
   };
 
-  constructor(index,w, h, image, color = "#FF00FF", tileOptions = {}) {
+  constructor(index, w, h, image, color = "#FF00FF", tileOptions = {}) {
     this.index = index;
     this.width = w;
     this.height = h;
-    this.image = image;
+
+    if (image instanceof Blob) {
+      this.blob = image;
+      this.image = URL.createObjectURL(image);
+    } else {
+      this.image = image;
+    }
+
     this.color = color;
     this.properties = { ...this.properties, ...tileOptions };
   }
@@ -38,7 +46,14 @@ export class Tile {
   }
 
   getImage() {
+    if (!this.image && this.blob) {
+      this.image = URL.createObjectURL(this.blob);
+    }
     return this.image;
+  }
+
+  getBlob() {
+    return this.blob;
   }
 
   getIndex() {


### PR DESCRIPTION
## Summary
- extend `pushImageIntoPalette` with optional color argument
- generate 12 colored tiles when creating a palette
- helper to build colored tile images using canvas
- create PNG blobs for generated tiles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846025b57388322b28e3d6a16a021f5