### PR TITLE
Add palette tile option presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
       <div>Current tile: <span id="current_tile"></span></div>
       <span>Current brush:</span>
       <x-tile-element name="brush_preview"></x-tile-element >
+      <tile-options></tile-options>
       <x-palette></x-palette>
     </side>
     <main name="viewport">

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ import { defaultImage, defaultImageWidth, defaultImageHeight } from "./staticDat
 import './canvasRenderer.js';
 import './palette.js';
 import './tileElement.js';
+import './tileOptions.js';
 import { ScenarioOptionsModal } from "./scenarioOptionsModal.js";
 import { SaveScenarioModal, LoadScenarioModal } from "./scenarioStorageModals.js";
 import { ContextWheel } from './contextWheel.js';

--- a/tileOptions.js
+++ b/tileOptions.js
@@ -1,0 +1,72 @@
+import { Scenario } from "./scenario.js";
+
+export class TileOptions extends HTMLElement {
+  tile = null;
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback() {
+    this.shadowRoot.addEventListener('change', this.onChange.bind(this));
+    window.addEventListener('brush.change', (e) => {
+      this.tile = e.detail;
+      this.render();
+    });
+    window.addEventListener('update.ui', () => this.render());
+    this.render();
+  }
+
+  onChange(event) {
+    if (!this.tile) return;
+    const input = event.target;
+    if (input.name === 'tile_option') {
+      const key = input.getAttribute('data-key');
+      const opts = { ...this.tile.getTileOptions() };
+      if (input.checked) {
+        opts[key] = true;
+      } else {
+        delete opts[key];
+      }
+      this.tile.setTileOptions(opts);
+      Scenario.getInstance().fireUpdate();
+    }
+  }
+
+  renderOptions(options) {
+    if (!this.tile) return '<div>No tile selected</div>';
+    const props = this.tile.getTileOptions();
+    return options.map((key) => {
+      const checked = props[key] ? 'checked' : '';
+      return `<label class="option"><input type="checkbox" name="tile_option" data-key="${key}" ${checked}/> ${key}</label>`;
+    }).join('');
+  }
+
+  render() {
+    const scenarioOptions = Scenario.getInstance().getOptions();
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          border: 1px solid #333;
+          border-radius: 4px;
+          padding: 4px;
+          margin-top: 4px;
+          background: #444;
+        }
+        .option {
+          display: flex;
+          gap: 4px;
+          align-items: center;
+          margin-bottom: 4px;
+        }
+      </style>
+      <details open>
+        <summary>Tile Options</summary>
+        ${this.renderOptions(scenarioOptions)}
+      </details>
+    `;
+  }
+}
+
+customElements.define('tile-options', TileOptions);

--- a/tools.js
+++ b/tools.js
@@ -18,10 +18,15 @@ export class Tools {
   }
 
   paintTool(cell, layer) {
-    cell.setTile(Tools.getInstance().currentBrush, layer);
+    const brush = Tools.getInstance().currentBrush;
+    cell.setTile(brush, layer);
+    if (brush) {
+      cell.setCellOptions(brush.getTileOptions());
+    }
   }
 
   fillTool(cell, layer) {
+    const brush = Tools.getInstance().currentBrush;
     const currentTile = cell.getTile(layer);
     let cells = new Set();
     cell.getAdjacentCellsWhere(cells, (adjacent, arr) => {
@@ -30,7 +35,10 @@ export class Tools {
 
 
     cells.forEach((cell) => {
-      cell.setTile(Tools.getInstance().currentBrush, layer);
+      cell.setTile(brush, layer);
+      if (brush) {
+        cell.setCellOptions(brush.getTileOptions());
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- allow setting default cell options per palette tile via new `tile-options` component
- apply selected tile's options when painting or filling

## Testing
- `node --check tools.js`
- `node --check tileOptions.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_684651fd18f0832287ec619c3178fe11