### PR TITLE
Fix tile options toggle persistence

### DIFF
--- a/tile.js
+++ b/tile.js
@@ -34,7 +34,7 @@ export class Tile {
   }
 
   setTileOptions(options) {
-    this.properties = { ...this.properties, ...options };
+    this.properties = { ...options };
   }
 
   getTileOptions() {

--- a/tileOptions.js
+++ b/tileOptions.js
@@ -44,6 +44,8 @@ export class TileOptions extends HTMLElement {
 
   render() {
     const scenarioOptions = Scenario.getInstance().getOptions();
+    const previous = this.shadowRoot.querySelector('details');
+    const wasOpen = previous ? previous.open : true;
     this.shadowRoot.innerHTML = `
       <style>
         :host {
@@ -61,11 +63,11 @@ export class TileOptions extends HTMLElement {
           margin-bottom: 4px;
         }
       </style>
-      <details open>
-        <summary>Tile Options</summary>
-        ${this.renderOptions(scenarioOptions)}
-      </details>
-    `;
+        <details ${wasOpen ? 'open' : ''}>
+          <summary>Tile Options</summary>
+          ${this.renderOptions(scenarioOptions)}
+        </details>
+      `;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep tile options collapsed state between renders
- allow unchecked options to clear from tile properties

## Testing
- `node --check tile.js`
- `node --check tileOptions.js`


------
https://chatgpt.com/codex/tasks/task_e_6846556a80108322aa2d7db070026499