### PR TITLE
Fix painting option clearing

### DIFF
--- a/tools.js
+++ b/tools.js
@@ -21,7 +21,12 @@ export class Tools {
     const brush = Tools.getInstance().currentBrush;
     cell.setTile(brush, layer);
     if (brush) {
-      cell.setCellOptions(brush.getTileOptions());
+      const options = brush.getTileOptions();
+      if (Object.keys(options).length === 0) {
+        cell.clearCellOptions();
+      } else {
+        cell.setCellOptions(options);
+      }
     }
   }
 
@@ -37,7 +42,12 @@ export class Tools {
     cells.forEach((cell) => {
       cell.setTile(brush, layer);
       if (brush) {
-        cell.setCellOptions(brush.getTileOptions());
+        const options = brush.getTileOptions();
+        if (Object.keys(options).length === 0) {
+          cell.clearCellOptions();
+        } else {
+          cell.setCellOptions(options);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure painting and filling clear cell options when the brush has none

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846599526d08322b01d1504a25f7967