### PR TITLE
Add layer visibility control

### DIFF
--- a/canvasRenderer.js
+++ b/canvasRenderer.js
@@ -247,6 +247,7 @@ export class XCanvasRenderer extends HTMLElement {
       max = min + 1;
     }
     for (let i = min; i < max; i++) {
+      if (!Scenario.getInstance().isLayerVisible(i)) continue;
       let batch = [];
       for (let c = 0; c < cells.length; c++) {
         let cell = cells[c];

--- a/layerOptions.js
+++ b/layerOptions.js
@@ -9,6 +9,7 @@ export class LayerOptions extends HTMLElement {
   connectedCallback() {
     this.render();
     this.shadowRoot.addEventListener("click", this.onClick.bind(this));
+    this.shadowRoot.addEventListener("change", this.onChange.bind(this));
     window.addEventListener("update.ui", () => this.update());
   }
 
@@ -23,6 +24,14 @@ export class LayerOptions extends HTMLElement {
     }
   }
 
+  onChange(event) {
+    const checkbox = event.target.closest('input[data-layer]');
+    if (checkbox) {
+      const layer = parseInt(checkbox.getAttribute('data-layer'));
+      Scenario.getInstance().setLayerVisibility(layer, checkbox.checked);
+    }
+  }
+
   update() {
     const scenario = Scenario.getInstance();
     const countSpan = this.shadowRoot.querySelector("#layer_count");
@@ -32,6 +41,14 @@ export class LayerOptions extends HTMLElement {
     const layerView = this.shadowRoot.querySelector('[name="current_layer"]');
     if (layerView) {
       layerView.textContent = `Current layer: ${scenario.currentLayer}`;
+    }
+    const list = this.shadowRoot.querySelector('#layer_visibility');
+    if (list) {
+      list.innerHTML = '';
+      for (let i = 0; i < scenario.layerCount; i++) {
+        const checked = scenario.isLayerVisible(i) ? 'checked' : '';
+        list.innerHTML += `<label><input type="checkbox" data-layer="${i}" ${checked}/> ${i}</label>`;
+      }
     }
   }
 
@@ -78,6 +95,7 @@ export class LayerOptions extends HTMLElement {
           <button id="layer_up">+</button>
           <button id="toggle_only_layer">Only</button>
         </div>
+        <div id="layer_visibility" class="row"></div>
       </details>
     `;
     this.update();

--- a/scenario.js
+++ b/scenario.js
@@ -23,6 +23,12 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     instance.setMapSize(data.mapSize[0], data.mapSize[1]);
     instance.currentLayer = 0;
     instance.layerCount = data.layerCount;
+    instance.visibleLayers = data.visibleLayers || {};
+    if (Object.keys(instance.visibleLayers).length === 0) {
+      for (let i = 0; i < instance.layerCount; i++) {
+        instance.visibleLayers[i] = true;
+      }
+    }
     instance.palette = data.palette.map(tile => Tile.deserialize(tile));
     instance.mapCells = data.mapCells.map(cell => Cell.deserialize(cell, instance.palette));
     instance.options = Options.deserialize(data.options, instance);
@@ -39,6 +45,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
   mapSize = [0, 0];
   mapCells = [];
   palette = [];
+  visibleLayers = {};
   updatingTimer = null;
   options = null;
 
@@ -53,7 +60,8 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
       mapCells: this.mapCells.map(cell => cell.serialize()),
       palette: this.palette.map(tile => tile.serialize()),
       layerCount: this.layerCount,
-      options: this.options.serialize()
+      options: this.options.serialize(),
+      visibleLayers: this.visibleLayers
     }
   }
 
@@ -93,6 +101,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     this.palette = [];
     this.layerCount = 1;
     this.currentLayer = 0;
+    this.visibleLayers = { 0: true };
     //this.pushImageIntoPalette(defaultImage, defaultImageWidth, defaultImageHeight);
     this.setMapSize(width, height);
     this.fireUpdate();
@@ -159,6 +168,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     if (this.layerCount >= Scenario.DEFAULT_UPPER_LAYER_LIMIT)
       return;
     this.layerCount += 1;
+    this.visibleLayers[this.layerCount - 1] = true;
     this.fireUpdate();
   }
 
@@ -166,6 +176,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     if (this.layerCount <= 1)
       return;
     this.layerCount -= 1;
+    delete this.visibleLayers[this.layerCount];
     this.mapCells.forEach(cell => {
       delete cell.tiles[this.layerCount];
     });
@@ -173,6 +184,15 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
       this.currentLayer = this.layerCount - 1;
     }
     this.fireUpdate();
+  }
+
+  setLayerVisibility(layer, visible) {
+    this.visibleLayers[layer] = visible;
+    this.fireUpdate();
+  }
+
+  isLayerVisible(layer) {
+    return this.visibleLayers[layer] !== false;
   }
 
   setMapHeight(height) {


### PR DESCRIPTION
## Summary
- extend scenario data with `visibleLayers` map
- persist visibility across serialization
- skip hidden layers during render
- expose checkboxes in layer options UI to toggle visibility

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ad409c46c83229aeca8bf4f32a01d