### PR TITLE
Add keyboard shortcuts and help modal

### DIFF
--- a/helpModal.js
+++ b/helpModal.js
@@ -1,0 +1,83 @@
+export class HelpModal extends HTMLElement {
+  open = false;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  connectedCallback() {
+    this.addEventListener('click', this.onClick.bind(this));
+    this.render();
+  }
+
+  onClick(e) {
+    const path = e.composedPath();
+    if (path.includes(this.shadowRoot.querySelector('button[name="close"]'))) {
+      this.closeDialog();
+    }
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: ${this.open ? 'block' : 'none'};
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 200, 200, 0.125);
+          z-index: 100;
+        }
+        .content {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          background-color: #333;
+          padding: 20px;
+          border-radius: 5px;
+          box-shadow: 0 0 10px rgba(0,0,0,0.5);
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+        }
+        button {
+          background:#555;
+          color:#FFF;
+          cursor:pointer;
+          border:2px solid #999;
+        }
+        ul { margin: 0; padding-left: 20px; }
+      </style>
+      <div class="content">
+        <div class="controls"><button name="close">X</button></div>
+        <h2>Keyboard Shortcuts</h2>
+        <ul>
+          <li><b>?</b> - Show this help</li>
+          <li><b>P</b> - Paint tool</li>
+          <li><b>F</b> - Fill tool</li>
+          <li><b>+</b>/<b>=</b> - Zoom in</li>
+          <li><b>-</b> - Zoom out</li>
+          <li><b>0</b> - Reset zoom</li>
+          <li><b>Ctrl+S</b> - Save scenario</li>
+          <li><b>Ctrl+L</b> - Load scenario</li>
+        </ul>
+      </div>
+    `;
+  }
+
+  openDialog() {
+    this.open = true;
+    this.render();
+  }
+
+  closeDialog() {
+    this.open = false;
+    this.render();
+  }
+}
+
+customElements.define('help-modal', HelpModal);

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <button id="load_palette">Load Palette</button>
       <button id="generate_palette">Generate Palette</button>
       <button id="scenario_options">Options</button>
+      <button id="show_help">Help</button>
     </nav>
     <side>
       <layer-options></layer-options>
@@ -45,5 +46,6 @@
     <scenario-options-modal></scenario-options-modal>
     <save-scenario-modal></save-scenario-modal>
     <load-scenario-modal></load-scenario-modal>
+    <help-modal></help-modal>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ import { ScenarioOptionsModal } from "./scenarioOptionsModal.js";
 import { SaveScenarioModal, LoadScenarioModal } from "./scenarioStorageModals.js";
 import { ContextWheel } from './contextWheel.js';
 import './layerOptions.js';
+import './helpModal.js';
 
 function generateColorTile(color, width, height) {
   const canvas = document.createElement('canvas');
@@ -38,6 +39,8 @@ document.addEventListener("DOMContentLoaded", function () {
   let scenarioOptionsButton = document.querySelector("button#scenario_options");
   let saveLocalButton = document.querySelector("button#save_local");
   let loadLocalButton = document.querySelector("button#load_local");
+  let helpButton = document.querySelector("button#show_help");
+  let helpModal = document.querySelector("help-modal");
 
   window.addEventListener("tile.interact", function (event) {
     currentTileSpan.innerText = `${event.detail.x}, ${event.detail.y}`;
@@ -70,6 +73,10 @@ document.addEventListener("DOMContentLoaded", function () {
       document.body.appendChild(modal);
     }
     modal.openDialog();
+  });
+
+  helpButton?.addEventListener('click', function () {
+    helpModal?.openDialog();
   });
 
   saveButton.addEventListener("click", function () {
@@ -478,5 +485,33 @@ document.addEventListener("DOMContentLoaded", function () {
       action: () => tool.action(event)
     }));
     ContextWheel.Show(event.clientX, event.clientY, opts);
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName))
+      return;
+
+    if (e.key === '?' || e.key === 'h' || e.key === 'H') {
+      e.preventDefault();
+      helpModal?.openDialog();
+    } else if (e.key.toLowerCase() === 'p') {
+      Scenario.getInstance().setCurrentTool(Tools.getInstance().paintTool);
+      currentToolSpan.innerHTML = '🖌️ Paint tool';
+    } else if (e.key.toLowerCase() === 'f') {
+      Scenario.getInstance().setCurrentTool(Tools.getInstance().fillTool);
+      currentToolSpan.innerHTML = '🪣 Fill tool';
+    } else if (e.key === '+' || e.key === '=') {
+      renderer.zoomIn();
+    } else if (e.key === '-') {
+      renderer.zoomOut();
+    } else if (e.key === '0') {
+      renderer.zoomReset();
+    } else if (e.key.toLowerCase() === 's' && e.ctrlKey) {
+      e.preventDefault();
+      saveButton.click();
+    } else if (e.key.toLowerCase() === 'l' && e.ctrlKey) {
+      e.preventDefault();
+      loadButton.click();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- enable keyboard shortcuts in `main.js`
- show a help dialog listing available shortcuts
- import and register the new `help-modal` web component

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ad40ab8c8832280d72eb333a16f45