### PR TITLE
Add TMX/CSV import and export

### DIFF
--- a/exporters.js
+++ b/exporters.js
@@ -1,0 +1,124 @@
+import { Scenario } from './scenario.js';
+import { Tile } from './tile.js';
+import { defaultImage, defaultImageWidth, defaultImageHeight } from './staticData.js';
+
+export function scenarioToCSV(scenario) {
+  const lines = [];
+  const width = scenario.getMapWidth();
+  const height = scenario.getMapHeight();
+  for (let y = 0; y < height; y++) {
+    const row = [];
+    for (let x = 0; x < width; x++) {
+      const cell = scenario.getCellAt(x, y);
+      const tile = cell?.getTile(0);
+      row.push(tile ? tile.getIndex() : -1);
+    }
+    lines.push(row.join(','));
+  }
+  return lines.join('\n');
+}
+
+export function csvToScenario(csv) {
+  const rows = csv.trim().split(/\r?\n/).filter(r => r.length > 0);
+  const height = rows.length;
+  const width = rows[0].split(',').length;
+  const scenario = Scenario.getInstance();
+  scenario.newScenario(width, height);
+  scenario.layerCount = 1;
+  const palette = [];
+  for (let y = 0; y < height; y++) {
+    const values = rows[y].split(',').map(v => parseInt(v, 10));
+    for (let x = 0; x < width; x++) {
+      const idx = values[x];
+      const cell = scenario.getCellAt(x, y);
+      if (idx >= 0) {
+        if (!palette[idx]) {
+          const color = '#' + ((idx * 999999) % 0xffffff).toString(16).padStart(6, '0');
+          palette[idx] = new Tile(idx, defaultImageWidth, defaultImageHeight, defaultImage, color);
+        }
+        cell.setTile(palette[idx], 0);
+      } else {
+        cell.setTile(null, 0);
+      }
+    }
+  }
+  scenario.palette = palette;
+  scenario.fireUpdate(true);
+}
+
+export function scenarioToTMX(scenario) {
+  const width = scenario.getMapWidth();
+  const height = scenario.getMapHeight();
+  const tileWidth = scenario.getPalette()[0]?.width || defaultImageWidth;
+  const tileHeight = scenario.getPalette()[0]?.height || defaultImageHeight;
+  const parts = [];
+  parts.push('<?xml version="1.0" encoding="UTF-8"?>');
+  parts.push(`<map version="1.0" tiledversion="1.10" orientation="orthogonal" renderorder="right-down" width="${width}" height="${height}" tilewidth="${tileWidth}" tileheight="${tileHeight}">`);
+  parts.push(` <tileset firstgid="1" name="tileset" tilewidth="${tileWidth}" tileheight="${tileHeight}" tilecount="${scenario.getPalette().length}" columns="0">`);
+  scenario.getPalette().forEach(tile => {
+    parts.push(`  <tile id="${tile.getIndex()}">`);
+    parts.push(`   <image width="${tile.width}" height="${tile.height}" source="${tile.getImage()}"/>`);
+    parts.push('  </tile>');
+  });
+  parts.push(' </tileset>');
+  for (let l = 0; l < scenario.layerCount; l++) {
+    parts.push(` <layer id="${l + 1}" name="Layer ${l}" width="${width}" height="${height}">`);
+    parts.push('  <data encoding="csv">');
+    for (let y = 0; y < height; y++) {
+      const row = [];
+      for (let x = 0; x < width; x++) {
+        const cell = scenario.getCellAt(x, y);
+        const tile = cell?.getTile(l);
+        row.push(tile ? tile.getIndex() + 1 : 0);
+      }
+      parts.push(row.join(','));
+    }
+    parts.push('  </data>');
+    parts.push(' </layer>');
+  }
+  parts.push('</map>');
+  return parts.join('\n');
+}
+
+export function tmxToScenario(tmx) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(tmx, 'text/xml');
+  const map = doc.querySelector('map');
+  const width = parseInt(map.getAttribute('width'));
+  const height = parseInt(map.getAttribute('height'));
+  const mapTileWidth = parseInt(map.getAttribute('tilewidth')) || defaultImageWidth;
+  const mapTileHeight = parseInt(map.getAttribute('tileheight')) || defaultImageHeight;
+  const tileset = doc.querySelector('tileset');
+  const tileEls = tileset ? Array.from(tileset.querySelectorAll('tile')) : [];
+  const palette = [];
+  tileEls.forEach(tileEl => {
+    const id = parseInt(tileEl.getAttribute('id'));
+    const img = tileEl.querySelector('image');
+    const src = img?.getAttribute('source') || defaultImage;
+    const w = parseInt(img?.getAttribute('width')) || mapTileWidth;
+    const h = parseInt(img?.getAttribute('height')) || mapTileHeight;
+    const tile = new Tile(id, w, h, src);
+    palette[id] = tile;
+  });
+  const scenario = Scenario.getInstance();
+  scenario.newScenario(width, height);
+  scenario.layerCount = doc.querySelectorAll('layer').length;
+  scenario.palette = palette;
+  const layers = Array.from(doc.querySelectorAll('layer'));
+  layers.forEach((layerEl, lIdx) => {
+    const data = layerEl.querySelector('data');
+    const rows = data.textContent.trim().split(/\r?\n/);
+    for (let y = 0; y < rows.length; y++) {
+      const values = rows[y].split(',').map(v => parseInt(v, 10));
+      for (let x = 0; x < values.length; x++) {
+        const gid = values[x];
+        if (gid > 0) {
+          const tile = palette[gid - 1];
+          const cell = scenario.getCellAt(x, y);
+          cell.setTile(tile, lIdx);
+        }
+      }
+    }
+  });
+  scenario.fireUpdate(true);
+}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
       <button id="load">Load Scenario</button>
       <button id="save_local">Save to Local</button>
       <button id="load_local">Load from Local</button>
+      <button id="export_tmx">Export TMX</button>
+      <button id="import_tmx">Import TMX</button>
+      <button id="export_csv">Export CSV</button>
+      <button id="import_csv">Import CSV</button>
       <button id="new_scenario">New Scenario</button>
       <button id="load_palette">Load Palette</button>
       <button id="generate_palette">Generate Palette</button>

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ import { ScenarioOptionsModal } from "./scenarioOptionsModal.js";
 import { SaveScenarioModal, LoadScenarioModal } from "./scenarioStorageModals.js";
 import { ContextWheel } from './contextWheel.js';
 import './layerOptions.js';
+import { scenarioToCSV, csvToScenario, scenarioToTMX, tmxToScenario } from './exporters.js';
 
 function generateColorTile(color, width, height) {
   const canvas = document.createElement('canvas');
@@ -33,6 +34,10 @@ document.addEventListener("DOMContentLoaded", function () {
   let renderer = document.querySelector("x-renderer");
   let saveButton = document.querySelector("button#save");
   let loadButton = document.querySelector("button#load");
+  let exportTmxButton = document.querySelector("button#export_tmx");
+  let importTmxButton = document.querySelector("button#import_tmx");
+  let exportCsvButton = document.querySelector("button#export_csv");
+  let importCsvButton = document.querySelector("button#import_csv");
   let currentToolSpan = document.querySelector("span#current_tool");
   let currentTileSpan = document.querySelector("span#current_tile");
   let scenarioOptionsButton = document.querySelector("button#scenario_options");
@@ -70,6 +75,60 @@ document.addEventListener("DOMContentLoaded", function () {
       document.body.appendChild(modal);
     }
     modal.openDialog();
+  });
+
+  exportTmxButton.addEventListener("click", function () {
+    const tmx = scenarioToTMX(Scenario.getInstance());
+    const blob = new Blob([tmx], { type: "text/xml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "scenario.tmx";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importTmxButton.addEventListener("click", function () {
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.accept = ".tmx,.xml";
+    fileInput.addEventListener("change", function () {
+      const file = this.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        tmxToScenario(reader.result);
+      };
+      reader.readAsText(file);
+    });
+    fileInput.click();
+  });
+
+  exportCsvButton.addEventListener("click", function () {
+    const csv = scenarioToCSV(Scenario.getInstance());
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "scenario.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importCsvButton.addEventListener("click", function () {
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.accept = ".csv";
+    fileInput.addEventListener("change", function () {
+      const file = this.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        csvToScenario(reader.result);
+      };
+      reader.readAsText(file);
+    });
+    fileInput.click();
   });
 
   saveButton.addEventListener("click", function () {


### PR DESCRIPTION
## Summary
- implement CSV/TMX exporters and importers
- hook up new buttons to save/load via those formats
- expose the buttons in the HTML navigation

## Testing
- `node --check exporters.js`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_685ad412dd5483228266e95d81d98301