### PR TITLE
Add undo/redo history functionality

### DIFF
--- a/history.js
+++ b/history.js
@@ -1,0 +1,46 @@
+import { Scenario } from './scenario.js';
+
+export class History {
+  static instance = null;
+
+  static getInstance() {
+    if (!History.instance) {
+      History.instance = new History();
+    }
+    return History.instance;
+  }
+
+  constructor() {
+    this.undoStack = [];
+    this.redoStack = [];
+  }
+
+  pushState(state) {
+    // store state as JSON string to avoid mutation
+    const serialized = JSON.stringify(state);
+    this.undoStack.push(serialized);
+    if (this.undoStack.length > 50) {
+      this.undoStack.shift();
+    }
+    this.redoStack = [];
+  }
+
+  undo() {
+    if (this.undoStack.length <= 1) return;
+    const current = this.undoStack.pop();
+    this.redoStack.push(current);
+    const prev = this.undoStack[this.undoStack.length - 1];
+    if (prev) {
+      Scenario.deserialize(JSON.parse(prev));
+    }
+  }
+
+  redo() {
+    if (this.redoStack.length === 0) return;
+    const state = this.redoStack.pop();
+    this.undoStack.push(state);
+    Scenario.deserialize(JSON.parse(state));
+  }
+}
+
+window.HISTORY = History.getInstance();

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
       <button id="new_scenario">New Scenario</button>
       <button id="load_palette">Load Palette</button>
       <button id="generate_palette">Generate Palette</button>
+      <button id="undo">Undo</button>
+      <button id="redo">Redo</button>
       <button id="scenario_options">Options</button>
     </nav>
     <side>

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ import { Tools } from "./tools.js";
 import { defaultImage, defaultImageWidth, defaultImageHeight } from "./staticData.js";
 //import './renderer.js';
 import './canvasRenderer.js';
+import { History } from "./history.js";
 import './palette.js';
 import './tileElement.js';
 import './tileOptions.js';
@@ -38,6 +39,8 @@ document.addEventListener("DOMContentLoaded", function () {
   let scenarioOptionsButton = document.querySelector("button#scenario_options");
   let saveLocalButton = document.querySelector("button#save_local");
   let loadLocalButton = document.querySelector("button#load_local");
+  let undoButton = document.querySelector("button#undo");
+  let redoButton = document.querySelector("button#redo");
 
   window.addEventListener("tile.interact", function (event) {
     currentTileSpan.innerText = `${event.detail.x}, ${event.detail.y}`;
@@ -70,6 +73,12 @@ document.addEventListener("DOMContentLoaded", function () {
       document.body.appendChild(modal);
     }
     modal.openDialog();
+  });
+  undoButton.addEventListener("click", function () {
+    History.getInstance().undo();
+  });
+  redoButton.addEventListener("click", function () {
+    History.getInstance().redo();
   });
 
   saveButton.addEventListener("click", function () {
@@ -478,5 +487,14 @@ document.addEventListener("DOMContentLoaded", function () {
       action: () => tool.action(event)
     }));
     ContextWheel.Show(event.clientX, event.clientY, opts);
+  });
+  document.addEventListener("keydown", function (e) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+      e.preventDefault();
+      History.getInstance().undo();
+    } else if ((e.ctrlKey || e.metaKey) && e.key === "y") {
+      e.preventDefault();
+      History.getInstance().redo();
+    }
   });
 });

--- a/scenario.js
+++ b/scenario.js
@@ -1,5 +1,6 @@
 import { Cell } from './cell.js';
 import { Tile } from './tile.js';
+import { History } from './history.js';
 import { Options } from './options.js';
 import { defaultImage, defaultImageWidth, defaultImageHeight } from './staticData.js';
 
@@ -27,6 +28,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     instance.mapCells = data.mapCells.map(cell => Cell.deserialize(cell, instance.palette));
     instance.options = Options.deserialize(data.options, instance);
     instance.setAdjacents();
+    History.getInstance().pushState(instance.serialize());
 
     requestAnimationFrame(() => {
       instance.fireUpdate(true);
@@ -45,6 +47,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
   constructor(width, height) {
     this.options = new Options(this);
     this.newScenario(width, height);
+    History.getInstance().pushState(this.serialize());
   }
 
   serialize() {
@@ -82,6 +85,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
       return;
 
     this.currentTool(cell, this.currentLayer);
+    History.getInstance().pushState(this.serialize());
     this.fireUpdate();
   }
 
@@ -95,6 +99,7 @@ static DEFAULT_UPPER_LAYER_LIMIT = 32;
     this.currentLayer = 0;
     //this.pushImageIntoPalette(defaultImage, defaultImageWidth, defaultImageHeight);
     this.setMapSize(width, height);
+    History.getInstance().pushState(this.serialize());
     this.fireUpdate();
   }
 


### PR DESCRIPTION
## Summary
- add a `history.js` module for undo/redo management
- store scenario state on each tool execution
- connect undo/redo to buttons and keyboard shortcuts
- expose new UI buttons in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4074ba483228ab6f79b56575763